### PR TITLE
fix raw usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,8 +37,8 @@ if(program.mbtilesFile && program.geojsonFile) {
       sources: [{
         name: 'osm',
         mbtiles: path.normalize(program.mbtilesFile),
-      }],
-      raw: true,
+        raw: true
+      }]
     })
     .on('reduce', (feature, tile) => {
       changedFeatureCount += feature.properties.total;

--- a/map.js
+++ b/map.js
@@ -4,17 +4,19 @@ const Changelog = require('./changelog');
 const turf = require('turf');
 
 // Turn BBOX into point (for overview)
-function generalizeAsPoint(ft) {
-    return turf.centroid(ft);
+function generalizeAsPoint(ft, tile) {
+    return turf.centroid(ft.toGeoJSON(tile[0], tile[1], tile[2]));
 }
 
 module.exports = function(tileLayers, tile, write, done) {
   const changelog = new Changelog(tile);
-  tileLayers.osm.osm.features.forEach(ft => changelog.track(ft));
+  for (var i = 0; i < tileLayers.osm.osm.length; i++) {
+    changelog.track(tileLayers.osm.osm.feature(i));
+  }
 
   const feature = changelog.toGeoJSON();
   if(global.mapOptions.usePoint) {
-    const pointFeature = generalizeAsPoint(feature);
+    const pointFeature = generalizeAsPoint(feature, tile);
     pointFeature.properties = feature.properties;
     done(null, pointFeature);
   } else {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "homepage": "https://github.com/lukasmartinelli/osm-activity#readme",
   "dependencies": {
     "JSONStream": "^1.1.4",
+    "commander": "^2.9.0",
     "fast-stats": "0.0.3",
     "geojson-stream": "0.0.1",
     "lodash": "^4.15.0",


### PR DESCRIPTION
`raw: true` is per source. Using this switches tile layers in the map.js script to be [vector-tile-js](https://github.com/mapbox/vector-tile-js) objects instead of a geojson featurecollections

Raw is ideal for analysis cases where you won't be using the actual geometry of features, or will only be using the geometry of a small portion of the features (like if you only wanted to work with highways and not touch the geometry of every other entity), because geometry is lazily decoded.

Using raw properly will make osm-analysis run even faster. On my quadcore macbook pro, osm-analysis for just the United States country extract took: 

Old: 7m50s
New: 4m20s

You shouldn't need a 40-core machine to process the world in 20 minutes 😀 

cc @lukasmartinelli 
